### PR TITLE
DSPDC-590 Add Flux CD installation to base infrastructure.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .terraform
+.helm
+.kubeconfig

--- a/environments/README.md
+++ b/environments/README.md
@@ -8,7 +8,8 @@ relatively stable, and not run all that often.
 
 Environment definitions consist of:
 1. A single Terraform module
-2. (TODO) A single Helm chart to deploy Argo CD + application specs.
+2. A deployment of Flux CD's Helm Operator
+2. (TODO) A single Helm chart to push HelmRelease specs to the operator
 
 Most of the "business logic" for these two pieces is tracked elsewhere, either in
 the [templates](../templates) directory or in entirely separate git repositories.

--- a/environments/dev/terraform/core.tf
+++ b/environments/dev/terraform/core.tf
@@ -4,6 +4,10 @@ provider google-beta {
   alias = "core"
 }
 
+variable kubeconfig_path {
+  type = string
+}
+
 module project_core {
   # NOTE: This path is where we expect the template to be mounted
   # within the Docker image we run in init.sh, not where we expect
@@ -17,4 +21,5 @@ module project_core {
   dns_zone_name = "monster-dev"
   k8s_cluster_size = 2
   k8s_machine_type = "n1-standard-2"
+  kubeconfig_path = var.kubeconfig_path
 }

--- a/environments/init.sh
+++ b/environments/init.sh
@@ -7,11 +7,23 @@ declare -r REPO_ROOT=$(cd $(dirname ${SCRIPT_DIR}) >/dev/null 2>&1 && pwd)
 # Associative array so we can look things up by string key.
 # The values don't matter as long as they're not empty.
 declare -rA ENVS=([dev]=valid)
-declare -r TERRAFORM_VERSION=0.12.17
 
+declare -ra NAMESPACES=(fluxcd)
+
+declare -r TERRAFORM=hashicorp/terraform:0.12.17
+declare -r KUBECTL=lachlanevenson/k8s-kubectl:v1.14.10
+declare -r HELM=lachlanevenson/k8s-helm:v3.0.2
+
+declare -r HELM_OPERATOR_VERSION=v1.0.0-rc5
+declare -r HELM_OPERATOR_CHART_VERSION=0.4.0
+
+
+#####
+## Run Terraform to initialize "always on" infrastructure
+## for a given environment.
+#####
 function apply_terraform () {
-  local -r env=$1
-  local -r tf_path=${SCRIPT_DIR}/${env}/terraform
+  local -r env_dir=$1
   local -r tf_template_path=${REPO_ROOT}/templates/terraform
 
   declare -ra terraform=(
@@ -31,23 +43,119 @@ function apply_terraform () {
     # Terraform template paths
     -v ${tf_template_path}:/templates
     # Terraform source paths
-    -v ${tf_path}:/module
-    -w /module
-    hashicorp/terraform:${TERRAFORM_VERSION}
+    -v ${env_dir}:/env
+    -w /env/terraform
+    ${TERRAFORM}
   )
 
-  rm -rf ${tf_path}/.terraform
+  rm -rf ${env_dir}/terraform/.terraform
   ${terraform[@]} init
-  ${terraform[@]} apply
+  ${terraform[@]} apply -var='kubeconfig_path=/env/.kubeconfig'
 }
 
-function install_argocd () {
-  # The plan is to have a "bootstrap" Helm chart which installs
-  # Argo CD + a bunch of Argo CD apps.
+
+#####
+## Initialize namespaces in the core GKE cluster so
+## we can deploy into them.
+##
+## Helm used to create namespaces automatically but
+## dropped the behavior in v3 to be consistent with
+## kubectl. It's probably better to be explicit anyway.
+#####
+function create_namespaces () {
+  local -r kubeconfig=$1
+
+  declare -ra kubectl=(
+    docker run
+    # NOTE: `-t` omitted here on purpose because it's incompatible
+    # with `-a stdin`.
+    --rm -i
+    # Read from stdin so we can pipe in YAML.
+    -a stdin -a stdout -a stderr
+    # Configure the client to point at the cluster.
+    -v ${kubeconfig}:/root/.kube/config
+    # Make sure it can auth with GKE.
+    -v ${HOME}/.config:/root/.config
+    ${KUBECTL}
+  )
+
+  for ns in ${NAMESPACES[@]}; do
+    # kubectl apply a HEREDOC containing YAML for each namespace.
+    #
+    # It'd be simpler if we could just `kubectl create namespace ${ns}`.
+    # We can't do that because `create` fails when there's already a
+    # namespace with the given name. `apply` is idempotent, but it
+    # only accepts YAML / JSON as input -_-
+    ${kubectl[@]} apply -f - <<EOF
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${ns}
+EOF
+  done
+}
+
+
+#####
+## Set up Flux CD's Helm Operator to manage deployments in GKE.
+#####
+function install_flux () {
+  local -r kubeconfig=$1 env_dir=$2
+
+  # Install the CRD definitions separately. Helm doesn't have
+  # a coherent story for handling these yet (since updating them
+  # the wrong way can result in all existing objects being deleted),
+  # so they're easier to handle out-of-band.
+  docker run --rm -it \
+    -v ${kubeconfig}:/root/.kube/config \
+    -v ${HOME}/.config:/root/.config \
+    ${KUBECTL} \
+    apply -f \
+    https://raw.githubusercontent.com/fluxcd/helm-operator/${HELM_OPERATOR_VERSION}/deploy/flux-helm-release-crd.yaml
+
+  # Install the Operator using Helm.
+  declare -ra helm=(
+    docker run
+    --rm -it
+    # Configure the client to point at the cluster.
+    -v ${kubeconfig}:/root/.kube/config
+    # Make sure it can auth with GKE.
+    -v ${HOME}/.config:/root/.config
+    # Persist Helm config across container runs.
+    -v ${env_dir}/.helm/plugins:/root/.local/share/helm/plugins
+    -v ${env_dir}/.helm/config:/root/.config/helm
+    -v ${env_dir}/.helm/cache:/root/.cache/helm
+    ${HELM}
+  )
+
+  rm -rf ${env_dir}/.helm
+  ${helm[@]} repo add fluxcd https://charts.fluxcd.io
+  ${helm[@]} upgrade helm-operator fluxcd/helm-operator \
+    --install \
+    --wait \
+    --namespace=fluxcd \
+    --version=${HELM_OPERATOR_CHART_VERSION} \
+    --set='helm.versions=v3' \
+    --set='rbac.pspEnabled=true'
+}
+
+
+#####
+## Install Flux HelmRelease CRDs for all the software we want to
+## have running in the core GKE cluster.
+##
+## The Helm Operator will monitor the git repo specified in each
+## CRD and re-deploy whenever the target ref changes.
+#####
+function install_charts () {
   1>&2 echo TODO
 }
 
-main () {
+
+#####
+## Script entrypoint.
+#####
+function main () {
   if [ $# -ne 1 ]; then
     1>&2 echo Usage: ${0} '<env>'
     exit 1
@@ -56,9 +164,21 @@ main () {
     exit 1
   fi
 
-  local -r env=$1
-  apply_terraform ${env}
-  install_argocd ${env}
+  # Start by running Terraform. This will set up infrastructure and
+  # generate configs needed for creating Helm releases.
+  #
+  # NOTE: Set the SKIP_TF env variable to any value to skip over this
+  # step when testing changes to the k8s portiion.
+  local -r env_dir=${SCRIPT_DIR}/$1
+  if [ -z ${SKIP_TF:-""} ]; then
+    apply_terraform ${env_dir}
+  fi
+
+  # Set up services in GKE.
+  local -r kubeconfig=${env_dir}/.kubeconfig
+  create_namespaces ${kubeconfig}
+  install_flux ${kubeconfig} ${env_dir}
+  install_charts
 }
 
 main ${@}

--- a/templates/terraform/core-project/k8s.tf
+++ b/templates/terraform/core-project/k8s.tf
@@ -28,3 +28,21 @@ module core_k8s_node_pool {
   machine_type = var.k8s_machine_type
   disk_size_gb = 10
 }
+
+# Write a kubeconfig for the cluster to disk, for use downstream.
+# Inspired by https://ahmet.im/blog/authenticating-to-gke-without-gcloud/
+resource local_file core_kubeconfig {
+  filename = var.kubeconfig_path
+  content = <<EOF
+apiVersion: v1
+kind: Config
+current-context: core-context
+contexts: [{name: core-context, context: {cluster: ${module.core_k8s_master.name}, user: local-user}}]
+users: [{name: local-user, user: {auth-provider: {name: gcp}}}]
+clusters:
+- name: ${module.core_k8s_master.name}
+  cluster:
+    server: "https://${module.core_k8s_master.endpoint}"
+    certificate-authority-data: "${module.core_k8s_master.ca_certificate}"
+EOF
+}

--- a/templates/terraform/core-project/variables.tf
+++ b/templates/terraform/core-project/variables.tf
@@ -17,3 +17,8 @@ variable k8s_machine_type {
   type = string
   description = "Machine type to use in the core k8s cluster."
 }
+
+variable kubeconfig_path {
+  type = string
+  description = "Local path where kubeconfig for the core GKE cluster should be written."
+}


### PR DESCRIPTION
Flux CD is/was a competitor to Argo CD. The projects have announced that they will eventually fuse (scheduled for 1.6 on the Argo side), so eventually we'll end up using features of both. For now we use Flux CD because it already has Helm 3 support.